### PR TITLE
Added ARM64 job to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ language: go
 # sudo: requried
 dist: bionic
 
+jobs:
+  - arch: amd64
+    env: TARGET=amd64
+  - arch: amd64
+    env: TARGET=ppc64le
+  - arch: arm64
+    env: TARGET=arm64
+
 services:
   - docker
 
@@ -20,12 +28,10 @@ env:
     - REPOSITORY_USER=${REPOSITORY_USER}
     - DOCKER_CLI_EXPERIMENTAL="enabled"
     - secure: "${REGISTRY_SECURE}"
-  jobs:
-    - TARGET=amd64
-    - TARGET=ppc64le
 
 before_install:
   - if [ "${REPOSITORY_NAME}" = "" ]; then export REPOSITORY_NAME=multus; fi
+  - if [ "${REPOSITORY_USER}" = "" ]; then export REPOSITORY_USER=nfvperobot; fi
   - sudo apt-get update -qq
   - go get github.com/mattn/goveralls
 
@@ -49,6 +55,12 @@ script:
       docker build -t ${REPOSITORY_USER}/${REPOSITORY_NAME}:latest-amd64 .
       docker build -t ${REPOSITORY_USER}/${REPOSITORY_NAME}:latest-ppc64le -f Dockerfile.ppc64le .
       docker build -t ${REPOSITORY_USER}/${REPOSITORY_NAME}-origin:latest -f Dockerfile.openshift .
+    fi
+  - |
+    if [ "${TARGET}" == "arm64" ]; then
+      sudo env PATH=${PATH} ./test.sh
+      goveralls -coverprofile=coverage.out -service=travis-ci
+      docker build -t ${REPOSITORY_USER}/${REPOSITORY_NAME}:latest-arm64 -f Dockerfile.arm64 .
     fi
 
 deploy:


### PR DESCRIPTION

**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**
**1. Patch Details:** Following file has been modified :

.travis.yml: 
* Modified ‘Jobs’ tag to include arch: arm64 with env: TARGET=arm64.
* Exported REPOSITORY_USER to ‘nfvperobot’, as the variable was not defined in .travis.yml, and even AMD64 jobs were failing due to this.
* In the ‘script’ tag, added condition for aarch64, and included ‘docker build’ for ‘Dockerfile.arm64’, for generating arm64 specific docker image.

**2. Testing Detail:**
Please find my Travis-ci testing jobs here: https://travis-ci.com/github/ra9501576600git/multus-cni

**3. PR Description:** Here is my commit message :

1. Modified ‘Jobs’ tag to include ARM64 architecture with env: TARGET=arm64.
2. Exported REPOSITORY_USER to ‘nfvperobot’.
3. In the ‘script’ tag, added condition for aarch64, and included ‘docker build’ for ‘Dockerfile.arm64’, for generating ARM64 docker image.

Signed-off-by: odidev <odidev@puresoftware.com>

**4. Peer Reviewer:** Pruthvi Teja
**5. Reviewer:** Rajeev Nayan

**Thanks
Rahul Aggarwal**